### PR TITLE
Update Run_UniDoc_from_scratch_structure_afdb.py

### DIFF
--- a/ted_consensus_1.0/scripts/Run_UniDoc_from_scratch_structure_afdb.py
+++ b/ted_consensus_1.0/scripts/Run_UniDoc_from_scratch_structure_afdb.py
@@ -9,7 +9,7 @@ from natsort import natsorted
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 BINDIR = os.path.join(SCRIPT_DIR, 'bin')
-UNIDOC = os.path.join(BINDIR, 'UniDoc_structure')
+UNIDOC = os.path.join(BINDIR, 'UniDoc_struct')
 STRIDE = os.path.join(BINDIR, 'stride')
 pdb_to_fasta = "pdb_tofasta"
 pdb_selres= "pdb_selres"


### PR DESCRIPTION
In the latest version of UniDoc （https://yanglab.qd.sdu.edu.cn/UniDoc/download/UniDoc.tgz), the bin directory contains UniDoc_struct and UniDoc_seq.