### PR TITLE
feat: install to custom dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+**/*.pyc
+__pycache__/
+
+ted_consensus_1.0/ted_consensus/
+ted_consensus_1.0/programs/*/weights/*.pt
+

--- a/ted_consensus_1.0/run_segmentation.sh
+++ b/ted_consensus_1.0/run_segmentation.sh
@@ -12,9 +12,9 @@ usage() {
 }
 
 # Check that the environment exists and activate it 
-VENV_DIR="ted_consensus"
-if [ -d "$VENV_DIR" ]; then
-    source $VENV_DIR/bin/activate
+venv_dir="${VENV_DIR:-ted_consensus}"
+if [ -d "$venv_dir" ]; then
+    source $venv_dir/bin/activate
 else
     echo "Virtual environment 'ted_consensus' does not exist."
     echo "Please run 'bash setup.sh' to create and set up the virtual environment."

--- a/ted_consensus_1.0/run_segmentation.sh
+++ b/ted_consensus_1.0/run_segmentation.sh
@@ -11,12 +11,17 @@ usage() {
     exit 1
 }
 
-# Check that the environment exists and activate it 
-venv_dir="${VENV_DIR:-ted_consensus}"
-if [ -d "$venv_dir" ]; then
-    source $venv_dir/bin/activate
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# install dir can be overridden by setting the INSTALL_DIR environment variable
+TED_INSTALL_DIR=${TED_INSTALL_DIR:-$SCRIPT_DIR}
+
+# Check that the environment exists and activate it
+VENV_DIR="${TED_INSTALL_DIR}/ted_consensus"
+if [ -d "$VENV_DIR" ]; then
+    source "${VENV_DIR}/bin/activate"
 else
-    echo "Virtual environment 'ted_consensus' does not exist."
+    echo "Virtual environment '${VENV_DIR}' does not exist."
     echo "Please run 'bash setup.sh' to create and set up the virtual environment."
     exit 1
 fi
@@ -46,12 +51,11 @@ if [ ! -d "$OUTPUT_DIR" ]; then
     mkdir -p "$OUTPUT_DIR"
 fi
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 PY=$(which python)
 
-SEGMENT="${SCRIPT_DIR}/scripts/segment.sh"
-CONSENSUS="${SCRIPT_DIR}/scripts/get_consensus.py"
-FILTER_DOMAINS="${SCRIPT_DIR}/scripts/filter_domains_consensus.py"
+SEGMENT="${TED_INSTALL_DIR}/scripts/segment.sh"
+CONSENSUS="${TED_INSTALL_DIR}/scripts/get_consensus.py"
+FILTER_DOMAINS="${TED_INSTALL_DIR}/scripts/filter_domains_consensus.py"
 
 # Run Merizo on the input directory
 out_merizo="${OUTPUT_DIR}/chopping_merizo.txt"

--- a/ted_consensus_1.0/run_segmentation.sh
+++ b/ted_consensus_1.0/run_segmentation.sh
@@ -5,6 +5,8 @@
 
 # Lau et al., 2024. Exploring structural diversity across the protein universe with The Encyclopedia of Domains.
 
+set -e -o pipefail
+
 # Function to display usage message
 usage() {
     echo "Usage: $0 -i <input_directory_with_pdb_files> -o <output_directory>"
@@ -57,10 +59,22 @@ SEGMENT="${TED_INSTALL_DIR}/scripts/segment.sh"
 CONSENSUS="${TED_INSTALL_DIR}/scripts/get_consensus.py"
 FILTER_DOMAINS="${TED_INSTALL_DIR}/scripts/filter_domains_consensus.py"
 
+# Print useful info
+echo "Input directory: ${INPUT_DIR}"
+echo "Output directory: ${OUTPUT_DIR}"
+echo "Python: ${PY}"
+echo "Segmentation script: ${SEGMENT}"
+echo "Consensus script: ${CONSENSUS}"
+echo "Filter domains script: ${FILTER_DOMAINS}"
+
+
 # Run Merizo on the input directory
 out_merizo="${OUTPUT_DIR}/chopping_merizo.txt"
 log_merizo="${OUTPUT_DIR}/chopping_merizo.log"
+echo "Running Merizo..."
+set -x
 bash "${SEGMENT}" -i "${INPUT_DIR}" -m merizo -o "${OUTPUT_DIR}" > "${log_merizo}" 2>&1
+set +x
 
 if test ! -f "${out_merizo}" || test ! -s "${out_merizo}"; then
     echo "Expected to find chopping file for Merizo at ${out_merizo}!"
@@ -70,7 +84,10 @@ fi
 # Run UniDoc on the Merizo output
 out_unidoc="${OUTPUT_DIR}/chopping_unidoc.txt"
 log_unidoc="${OUTPUT_DIR}/chopping_unidoc.log"
+echo "Running UniDoc on Merizo output..."
+set -x
 bash "${SEGMENT}" -i "${INPUT_DIR}" -m unidoc -o "${OUTPUT_DIR}" -c "${out_merizo}" > "${log_unidoc}" 2>&1
+set +x
 
 if test ! -f "${out_unidoc}" || test ! -s "${out_unidoc}"; then
     echo "Expected to find chopping file for UniDoc at ${out_unidoc}!"
@@ -80,7 +97,10 @@ fi
 # Run Chainsaw on the input directory
 out_chainsaw="${OUTPUT_DIR}/chopping_chainsaw.txt"
 log_chainsaw="${OUTPUT_DIR}/chopping_chainsaw.log"
+echo "Running Chainsaw..."
+set -x
 bash "${SEGMENT}" -i "${INPUT_DIR}" -m chainsaw -o "${OUTPUT_DIR}" > "${log_chainsaw}" 2>&1
+set +x
 
 if test ! -f "${out_chainsaw}" || test ! -s "${out_chainsaw}"; then
     echo "Expected to find chopping file for Chainsaw at ${out_chainsaw}!"

--- a/ted_consensus_1.0/scripts/Run_UniDoc_from_scratch_structure_afdb.py
+++ b/ted_consensus_1.0/scripts/Run_UniDoc_from_scratch_structure_afdb.py
@@ -95,7 +95,8 @@ def main():
                     chopping = "NULL"
                     ndoms = 0
                 
-            except:
+            except Exception as e:
+                print(f"Error processing {pdb_path}: {e}")
                 chopping = 'NO_SS'
                 ndoms = 0
 

--- a/ted_consensus_1.0/scripts/segment.sh
+++ b/ted_consensus_1.0/scripts/segment.sh
@@ -12,14 +12,18 @@
 
 set -eu
 
-# Directories and paths
+# Directory of this script
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-PROG_DIR="${SCRIPT_DIR}/../programs"
+
+# Install dir can be overridden by setting the INSTALL_DIR environment variable
+TED_INSTALL_DIR=${TED_INSTALL_DIR:-$( cd -- "$( dirname -- "${SCRIPT_DIR}" )" &> /dev/null && pwd )}
+
+PROG_DIR="${TED_INSTALL_DIR}/programs"
 
 py=$(which python)
 custom_chopping=''
 
-FILTER_DOMAINS="${SCRIPT_DIR}/filter_domains.py"
+FILTER_DOMAINS="${TED_INSTALL_DIR}/scripts/filter_domains.py"
 
 while getopts ":i:m:o:c:" opt; do
   case $opt in
@@ -40,7 +44,7 @@ done
 
 # Check if both options are provided
 if [[ -z "${inputs}" || -z "${method}" || -z "${output}" ]]; then
-  echo "Usage: run_segment_afdb.sh -i <structure_directory> -m <merizo/unidoc/chainsaw> -o <output_directory> [-c <chopping>]"
+  echo "Usage: segment.sh -i <structure_directory> -m <merizo/unidoc/chainsaw> -o <output_directory> [-c <chopping>]"
   exit 1
 fi
 
@@ -73,10 +77,16 @@ if [ "${method}" = "merizo" ] || [ "${method}" = "unidoc" ]; then
     target_list="${output%/}targets.txt"
     readlink -f "${inputs}/"*.pdb > "${target_list}"
 
+    echo "Running ${method} on target list ${target_list}"
+
     if [[ ${custom_chopping} == '' ]]; then
+        set -x
         ${py} "${RUN_SCRIPT}" -l "${target_list}" --out "${output_file}"
+        set +x
     else
+        set -x
         ${py} "${RUN_SCRIPT}" -l "${target_list}" --out "${output_file}" --inherit_chopping "${custom_chopping}"
+        set +x
     fi
 
     # Cleanup
@@ -90,6 +100,7 @@ fi
 
 # Filter choppings to remove small segments and single-residue domains
 if test -f "${output_file}"; then
+    echo "Filtering domains in ${output_file} ..."
     "${py}" "${FILTER_DOMAINS}" "${output_file}" -o "${output_file}.tmp" --offset_resi "${OFFSET_RESI}"
 
     if [ $? == 0 ]; then

--- a/ted_consensus_1.0/setup.sh
+++ b/ted_consensus_1.0/setup.sh
@@ -4,12 +4,17 @@
 # please cite the following paper:
 # Lau et al., 2024. Exploring structural diversity across the protein universe with The Encyclopedia of Domains.
 
+set -eo pipefail
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
+# install dir can be overridden by setting the INSTALL_DIR environment variable
+TED_INSTALL_DIR=${TED_INSTALL_DIR:-$SCRIPT_DIR}
+
 # Define the name of the virtual environment directory
-VENV_DIR="ted_consensus"
-WEIGHTS_DIR="${SCRIPT_DIR}/programs/merizo/weights"
-UNIDOC_DIR="${SCRIPT_DIR}/programs/unidoc"
+VENV_DIR="${TED_INSTALL_DIR}/ted_consensus"
+WEIGHTS_DIR="${TED_INSTALL_DIR}/programs/merizo/weights"
+UNIDOC_DIR="${TED_INSTALL_DIR}/programs/unidoc"
 
 # Define base URL and weights files in an array
 BASE_URL="https://github.com/psipred/Merizo/raw/main/weights"
@@ -17,7 +22,7 @@ WEIGHTS_FILES=("weights_part_0.pt" "weights_part_1.pt" "weights_part_2.pt")
 
 # UniDoc package download URL
 UNIDOC_URL="https://yanglab.qd.sdu.edu.cn/UniDoc/download/UniDoc.tgz"
-UNIDOC_TGZ="${SCRIPT_DIR}/programs/unidoc.tgz"
+UNIDOC_TGZ="${TED_INSTALL_DIR}/programs/unidoc.tgz"
 
 # Function to check Python version
 check_python_version() {
@@ -51,26 +56,43 @@ fi
 # Create a virtual environment
 if [ ! -d "$VENV_DIR" ]; then
     echo "Creating virtual environment..."
-    $PYTHON_COMMAND -m venv $VENV_DIR
+    "$PYTHON_COMMAND" -m venv "$VENV_DIR"
 else
     echo "Virtual environment already exists."
 fi
 
 # Activate the virtual environment
-source $VENV_DIR/bin/activate
+source "$VENV_DIR/bin/activate"
 
 # Upgrade pip to the latest version
 echo "Upgrading pip..."
 pip install --upgrade pip
 
 # Install dependencies from requirements.txt
-if [ -f "requirements.txt" ]; then
+if [ -f "${SCRIPT_DIR}/requirements.txt" ]; then
     echo "Installing dependencies from requirements.txt..."
-    pip install -r requirements.txt
+    pip install -r "${SCRIPT_DIR}/requirements.txt"
 else
-    echo "requirements.txt not found. Please make sure it exists in the current directory."
+    echo "Requirements file '${SCRIPT_DIR}/requirements.txt' not found. Please make sure it exists in the install directory."
     exit 1
 fi
+
+if [ ! -d "${TED_INSTALL_DIR}" ]; then
+    echo "Creating install directory..."
+    mkdir -p "${TED_INSTALL_DIR}"
+else
+    echo "Install directory already exists."
+fi
+
+# Copy over dirs if they do not exist
+for dirname in programs scripts; do
+    if [ ! -d "${TED_INSTALL_DIR}/${dirname}" ]; then
+        echo "Copying ${dirname} directory..."
+        cp -r "${SCRIPT_DIR}/${dirname}" "${TED_INSTALL_DIR}/${dirname}"
+    else
+        echo "${dirname} directory already exists."
+    fi
+done
 
 # Check if the weights directory exists
 if [ -d "$WEIGHTS_DIR" ]; then
@@ -94,16 +116,16 @@ if [ -d "$UNIDOC_DIR" ]; then
 else
     if test ! -f "${UNIDOC_TGZ}"; then
         echo "programs/unidoc directory not found. Downloading UniDoc ..."
-        wget -O "${UNIDOC_TGZ}" "${UNIDOC_URL}"
+        wget --no-check-certificate -O "${UNIDOC_TGZ}" "${UNIDOC_URL}"
     fi
 
     echo "Unpacking UniDoc package..."
-    tar -xzvf "${UNIDOC_TGZ}" -C "${SCRIPT_DIR}/programs"
-    mv "${SCRIPT_DIR}/programs/UniDoc" "${SCRIPT_DIR}/programs/unidoc"
-
-    # Copy the extra run script over to the unidoc dir
-    cp "scripts/Run_UniDoc_from_scratch_structure_afdb.py" "${UNIDOC_DIR}/"
+    tar -xzvf "${UNIDOC_TGZ}" -C "${TED_INSTALL_DIR}/programs"
+    mv "${TED_INSTALL_DIR}/programs/UniDoc" "${TED_INSTALL_DIR}/programs/unidoc"
 fi
+
+# Copy the extra run script over to the unidoc dir
+cp "${SCRIPT_DIR}/scripts/Run_UniDoc_from_scratch_structure_afdb.py" "${UNIDOC_DIR}/"
 
 # if running on macOS install compiler tools and compile stride from source:
 if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -115,7 +137,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
         read -p "Press enter after Xcode Command Line Tools installation is complete"
     fi
 
-    cd "${SCRIPT_DIR}/programs/chainsaw/stride" || exit
+    cd "${TED_INSTALL_DIR}/programs/chainsaw/stride" || exit
     # Remove all files except stride.tgz
     find . -type f ! -name 'stride.tgz' -delete
     # Extract the contents of stride.tgz

--- a/ted_consensus_1.0/setup.sh
+++ b/ted_consensus_1.0/setup.sh
@@ -146,7 +146,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
         read -p "Press enter after Xcode Command Line Tools installation is complete"
     fi
 
-    cd "${TED_INSTALL_DIR}/programs/chainsaw/stride" || exit
+    cd "${TED_INSTALL_DIR}/programs/chainsaw/stride"
     # Remove all files except stride.tgz
     find . -type f ! -name 'stride.tgz' -delete
     # Extract the contents of stride.tgz
@@ -155,8 +155,17 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     echo "Compiling stride for MacOS..."
     make
     chmod +x stride
+
+    echo "Copying stride binary to unidoc bin directory..."
+    cp stride "${UNIDOC_DIR}/bin"
+
+    echo "Compiling unidoc for MacOS..."
+    cd "${UNIDOC_DIR}/src"
+    rm -f UniDoc_struct UniDoc_seq ../bin/UniDoc_struct ../bin/UniDoc_seq
+    g++ -std=c++0x   -O3 -ffast-math -lm -o UniDoc_struct UniDoc_struct.cpp && mv UniDoc_struct ../bin/
+    g++ -std=c++0x   -O3 -ffast-math -lm -o UniDoc_seq UniDoc_seq.cpp && mv UniDoc_seq ../bin/
     # Change back to the original directory
-    cd - || exit
+    cd $SCRIPT_DIR
 fi
 
 echo "Successfully set up ted_consensus"

--- a/ted_consensus_1.0/setup.sh
+++ b/ted_consensus_1.0/setup.sh
@@ -122,6 +122,15 @@ else
     echo "Unpacking UniDoc package..."
     tar -xzvf "${UNIDOC_TGZ}" -C "${TED_INSTALL_DIR}/programs"
     mv "${TED_INSTALL_DIR}/programs/UniDoc" "${TED_INSTALL_DIR}/programs/unidoc"
+
+    # macOS C/C++ compatibility: replace non-portable <malloc.h> with <stdlib.h>
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "Patching UniDoc C/C++ sources for macOS (malloc.h -> stdlib.h)..."
+        # Replace in all source files under UniDoc
+        while IFS= read -r -d '' hdr; do
+            sed -E -i '' 's#<malloc.h>#<stdlib.h>#g' "$hdr"
+        done < <(find "${UNIDOC_DIR}" -type f \( -name "*.h" -o -name "*.hpp" -o -name "*.c" -o -name "*.cpp" \) -print0)
+    fi
 fi
 
 # Copy the extra run script over to the unidoc dir


### PR DESCRIPTION
Allows ted-tools to be installed and run from an optional custom directory specified by env `TED_INSTALL_DIR`.

If specified, `TED_INSTALL_DIR` needs to be the same for both `setup.sh` and `run_segmentation.sh`

Also:
- fix: download unidoc with `--no-check-certificate` (their SSL is failing)